### PR TITLE
Require origin whitelist for CORS middleware

### DIFF
--- a/rest/middleware/cors.go
+++ b/rest/middleware/cors.go
@@ -1,16 +1,97 @@
 package middleware
 
-import "net/http"
+import (
+	"net/http"
+	"net/url"
+	"strings"
 
-// CORSMiddleware enables cross-origin requests. It implements the Middleware
-// interface.
-func CORSMiddleware(w http.ResponseWriter, r *http.Request) bool {
-	if origin := r.Header.Get("Origin"); origin != "" {
-		w.Header().Set("Access-Control-Allow-Origin", origin)
-		w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE")
-		w.Header()["Access-Control-Allow-Headers"] = r.Header["Access-Control-Request-Headers"]
-		w.Header().Set("Access-Control-Allow-Credentials", "true")
+	"github.com/Workiva/go-rest/rest"
+)
+
+type corsError struct {
+	msg  string
+	code int
+}
+
+func (c *corsError) Code() int {
+	return c.code
+}
+
+func (c *corsError) Response() []byte {
+	return []byte(c.msg)
+}
+
+func (c *corsError) Error() string {
+	return c.msg
+}
+
+// NewCORSMiddleware returns a Middleware which enables cross-origin requests.
+// Origin must match the supplied whitelist (which supports wildcards). Returns
+// a MiddlewareError if the request should be terminated.
+func NewCORSMiddleware(originWhitelist []string) rest.Middleware {
+	return func(w http.ResponseWriter, r *http.Request) rest.MiddlewareError {
+		originMatch := false
+		if origin := r.Header.Get("Origin"); checkOrigin(origin, originWhitelist) {
+			w.Header().Set("Access-Control-Allow-Origin", origin)
+			w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE")
+			w.Header()["Access-Control-Allow-Headers"] = r.Header["Access-Control-Request-Headers"]
+			w.Header().Set("Access-Control-Allow-Credentials", "true")
+			originMatch = true
+		}
+
+		var err rest.MiddlewareError
+		if r.Method == "OPTIONS" {
+			err = &corsError{code: http.StatusOK}
+		}
+		if !originMatch {
+			err = &corsError{
+				code: http.StatusBadRequest,
+				msg:  "Origin does not match whitelist",
+			}
+		}
+		return err
+	}
+}
+
+// checkOrigin checks if the given origin is contained in the origin whitelist.
+// Returns true if the origin is in the whitelist, false if not.
+func checkOrigin(origin string, whitelist []string) bool {
+	url, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+	originComponents := strings.Split(url.Host, ".")
+
+checkWhitelist:
+	for _, whitelisted := range whitelist {
+		if whitelisted == "*" {
+			return true
+		}
+
+		whitelistedComponents := strings.Split(whitelisted, ".")
+
+		if len(originComponents) != len(whitelistedComponents) {
+			// Do not match, try next host in whitelist.
+			continue
+		}
+
+		for i, originComponent := range originComponents {
+			whitelistedComponent := whitelistedComponents[i]
+			if whitelistedComponent == "*" {
+				// Wildcard, check next component.
+				continue
+			}
+
+			if originComponent != whitelistedComponent {
+				// Mismatch, try next host in whitelist.
+				continue checkWhitelist
+			}
+		}
+
+		// Origin matches whitelisted domain.
+		return true
 	}
 
-	return r.Method == "OPTIONS"
+	// No matches.
+	return false
 }

--- a/rest/middleware/cors_test.go
+++ b/rest/middleware/cors_test.go
@@ -8,26 +8,59 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// Ensures that CORSMiddleware applies the headers needed for CORS and returns
-// true for non-OPTIONS requests.
-func TestCORSMiddleware(t *testing.T) {
+// Ensures that CORSMiddleware applies the headers needed for CORS when * is
+// present in the whitelist.
+func TestCORSMiddlewareAll(t *testing.T) {
 	assert := assert.New(t)
 	req, _ := http.NewRequest("GET", "http://example.com/foo", nil)
-	req.Header.Set("Origin", "abc")
+	req.Header.Set("Origin", "http://foo.com")
 	req.Header.Set("Access-Control-Request-Headers", "def")
 	w := httptest.NewRecorder()
-	assert.False(CORSMiddleware(w, req))
+	assert.Nil(NewCORSMiddleware([]string{"*"})(w, req))
 
-	assert.Equal("abc", w.Header().Get("Access-Control-Allow-Origin"))
+	assert.Equal("http://foo.com", w.Header().Get("Access-Control-Allow-Origin"))
 	assert.Equal("POST, GET, OPTIONS, PUT, DELETE", w.Header().Get("Access-Control-Allow-Methods"))
 	assert.Equal([]string{"def"}, w.Header()["Access-Control-Allow-Headers"])
 	assert.Equal([]string{"true"}, w.Header()["Access-Control-Allow-Credentials"])
 }
 
-// Ensures that CORSMiddleware returns true for OPTIONS requests.
+// Ensures that CORSMiddleware applies the headers needed for CORS and respects
+// the origin whitelist.
+func TestCORSMiddlewareWhitelist(t *testing.T) {
+	assert := assert.New(t)
+	req, _ := http.NewRequest("GET", "http://example.com/foo", nil)
+	req.Header.Set("Origin", "http://foo.wdesk.com")
+	req.Header.Set("Access-Control-Request-Headers", "def")
+	w := httptest.NewRecorder()
+	middleware := NewCORSMiddleware([]string{"blah.wdesk.org", "*.wdesk.com"})
+	assert.Nil(middleware(w, req))
+
+	assert.Equal("http://foo.wdesk.com", w.Header().Get("Access-Control-Allow-Origin"))
+	assert.Equal("POST, GET, OPTIONS, PUT, DELETE", w.Header().Get("Access-Control-Allow-Methods"))
+	assert.Equal([]string{"def"}, w.Header()["Access-Control-Allow-Headers"])
+	assert.Equal([]string{"true"}, w.Header()["Access-Control-Allow-Credentials"])
+
+	// Mismatched origin
+	req, _ = http.NewRequest("GET", "http://example.com/foo", nil)
+	req.Header.Set("Origin", "http://baz.wdesk.org")
+	req.Header.Set("Access-Control-Request-Headers", "def")
+	w = httptest.NewRecorder()
+	err := middleware(w, req)
+	assert.Error(err)
+	assert.Equal(http.StatusBadRequest, err.Code())
+
+	assert.Equal("", w.Header().Get("Access-Control-Allow-Origin"))
+	assert.Equal("", w.Header().Get("Access-Control-Allow-Methods"))
+	assert.Nil(w.Header()["Access-Control-Allow-Headers"])
+	assert.Nil(w.Header()["Access-Control-Allow-Credentials"])
+}
+
+// Ensures that CORSMiddleware returns a MiddlewareError with a 200 response
+// code.
 func TestCORSMiddlewareOptionsRequest(t *testing.T) {
 	req, _ := http.NewRequest("OPTIONS", "http://example.com/foo", nil)
-	req.Header.Set("Origin", "abc")
+	req.Header.Set("Origin", "http://foo.com")
 	w := httptest.NewRecorder()
-	assert.True(t, CORSMiddleware(w, req))
+	err := NewCORSMiddleware([]string{"foo.com"})(w, req)
+	assert.Equal(t, http.StatusOK, err.Code())
 }


### PR DESCRIPTION
Require an origin whitelist for CORS middleware. Reject requests having an origin that does not match the whitelist.

@matthewsullivan-wf @Workiva/messaging-pp
